### PR TITLE
Add flag for paygas mode to EVM interpreter

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -38,6 +38,9 @@ type Config struct {
 	EVMInterpreter   string // External EVM interpreter options
 
 	ExtraEips []int // Additional EIPS that are to be enabled
+
+	// paygasMode sets the behavior of the PAYGAS opcode.
+	PaygasMode PaygasMode
 }
 
 // Interpreter is used to run Ethereum based contracts and will utilise the
@@ -82,6 +85,8 @@ type keccakState interface {
 type EVMInterpreter struct {
 	evm *EVM
 	cfg Config
+
+	paygasMode PaygasMode
 
 	intPool *intPool
 
@@ -128,6 +133,7 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	}
 
 	return &EVMInterpreter{
+		paygasMode: cfg.PaygasMode,
 		evm: evm,
 		cfg: cfg,
 	}

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -63,6 +63,17 @@ var (
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]operation
 
+type PaygasMode = uint
+
+const (
+	// Calling the PAYGAS opcode does nothing.
+	PaygasNoOp PaygasMode = iota
+	// Execution terminates as soon as PAYGAS is called.
+	PaygasHalt
+	// Execution continues after PAYGAS is called.
+	PaygasContinue
+)
+
 func newAccountAbstractionInstructionSet() JumpTable {
 	instructionSet := newIstanbulInstructionSet()
 


### PR DESCRIPTION
Really short PR that adds a new config flag to set the mode of the `PAYGAS` opcode. The option is a NoOp for now.