### PR TITLE
Respect --fakepow

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1332,6 +1332,9 @@ func setTxPool(ctx *cli.Context, cfg *core.TxPoolConfig) {
 }
 
 func setEthash(ctx *cli.Context, cfg *eth.Config) {
+	if ctx.GlobalIsSet(FakePoWFlag.Name) {
+		cfg.Ethash.PowMode = ethash.ModeFake
+	}
 	if ctx.GlobalIsSet(EthashCacheDirFlag.Name) {
 		cfg.Ethash.CacheDir = ctx.GlobalString(EthashCacheDirFlag.Name)
 	}


### PR DESCRIPTION
This patch allows us to run geth in full node mode without checking to POW validity in headers. It will need to be removed before being merged upstream. 

Does any one have a recommendation on how to maintain this dependency since it only exists during the development phase? One idea I had was not including this in our branch at all, but instead using the diff to patch the code base when using Bazooka. I think that would end up becoming a hassle though. Open to other thoughts.