### PR TITLE
Add Tests for Transaction Validation

### DIFF
--- a/core/aa_transaction_test.go
+++ b/core/aa_transaction_test.go
@@ -1,0 +1,94 @@
+// Copyright 2015 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+const (
+	codeWithoutPaygas = "3373ffffffffffffffffffffffffffffffffffffffff1460245736601f57005b600080fd5b00"
+	codeWithPaygas    = "3373ffffffffffffffffffffffffffffffffffffffff1460245736601f57005b600080fd5b6001aa00"
+)
+
+func aaTransaction(to common.Address, gaslimit uint64) *types.Transaction {
+	return types.NewTransaction(0, to, big.NewInt(0), gaslimit, big.NewInt(0), nil).WithAASignature()
+}
+
+func setupBlockchain(blockGasLimit uint64) *BlockChain {
+	genesis := Genesis{Config: params.AllEthashProtocolChanges, GasLimit: blockGasLimit}
+	database := rawdb.NewMemoryDatabase()
+	genesis.MustCommit(database)
+	blockchain, _ := NewBlockChain(database, nil, genesis.Config, ethash.NewFaker(), vm.Config{}, nil)
+	return blockchain
+}
+
+func doValidate(blockchain *BlockChain, statedb *state.StateDB, transaction *types.Transaction, validationGasLimit uint64) error {
+	var (
+		snapshotRevisionId = statedb.Snapshot()
+		context            = NewEVMContext(types.AADummyMessage, blockchain.CurrentHeader(), blockchain, &common.Address{})
+		vmenv              = vm.NewEVM(context, statedb, blockchain.Config(), vm.Config{})
+	)
+	defer statedb.RevertToSnapshot(snapshotRevisionId)
+	return Validate(transaction, types.HomesteadSigner{}, vmenv, validationGasLimit)
+}
+
+func TestAATransactionValidation(t *testing.T) {
+	var (
+		blockchain = setupBlockchain(10000000)
+		statedb, _ = blockchain.State()
+
+		key, _                = crypto.GenerateKey()
+		contractCreator       = crypto.PubkeyToAddress(key.PublicKey)
+		contractWithoutPaygas = crypto.CreateAddress(contractCreator, 0)
+		contractWithPaygas    = crypto.CreateAddress(contractCreator, 1)
+	)
+	statedb.SetBalance(contractWithoutPaygas, big.NewInt(1000000))
+	statedb.SetCode(contractWithoutPaygas, common.FromHex(codeWithoutPaygas))
+	statedb.SetBalance(contractWithPaygas, big.NewInt(100000))
+	statedb.SetCode(contractWithPaygas, common.FromHex(codeWithPaygas))
+
+	tx := aaTransaction(contractWithoutPaygas, 100000)
+	if err := doValidate(blockchain, statedb, tx, 400000); err != ErrNoPaygas {
+		t.Error("\n\texpected:", ErrNoPaygas, "\n\tgot:", err)
+	}
+
+	tx = aaTransaction(contractWithPaygas, 100000)
+	if err := doValidate(blockchain, statedb, tx, 400000); err != nil {
+		t.Error("\n\texpected:", "no error", "\n\tgot:", err)
+	}
+
+	tx = aaTransaction(contractWithPaygas, 1)
+	if err := doValidate(blockchain, statedb, tx, 400000); err != ErrIntrinsicGas {
+		t.Error("\n\texpected:", ErrIntrinsicGas, "\n\tgot:", err)
+	}
+
+	tx = aaTransaction(contractWithPaygas, 1000000)
+	if err := doValidate(blockchain, statedb, tx, 400000); err != vm.ErrPaygasInsufficientFunds {
+		t.Error("\n\texpected:", vm.ErrPaygasInsufficientFunds, "\n\tgot:", err)
+	}
+}

--- a/core/aa_transaction_test.go
+++ b/core/aa_transaction_test.go
@@ -35,8 +35,15 @@ const (
 	contractCode = "3373ffffffffffffffffffffffffffffffffffffffff1460245736601f57005b600080fd5b60016000355b81900380602a57602035603957005b604035aa00"
 )
 
+// aaTransaction creates a new AA transaction to a deployed instance of the test contract.
+// Parameters are the contract address, the transaction gas limit,
+// the number of loops to run inside the contract (minimum: 1, gas per loop: 26),
+// whether to call PAYGAS at the end, the gas price to be returned from PAYGAS (if called).
 func aaTransaction(to common.Address, gaslimit uint64, loops uint64, callPaygas bool, gasPrice *big.Int) *types.Transaction {
 	data := make([]byte, 0x60)
+	if loops == 0 {
+		loops = 1
+	}
 	binary.BigEndian.PutUint64(data[0x18:0x20], loops)
 	if callPaygas {
 		data[0x3f] = 1

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -297,7 +297,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		}
 		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
 		if msg.IsAA() && st.evm.PaygasMode() != vm.PaygasNoOp {
-			if vmerr == vm.ErrPaygasInsufficientFunds {
+			if vmerr != nil {
 				return nil, vmerr
 			} else {
 				return nil, ErrNoPaygas

--- a/core/transaction_validator.go
+++ b/core/transaction_validator.go
@@ -27,7 +27,9 @@ var (
 )
 
 func Validate(tx *types.Transaction, s types.Signer, evm *vm.EVM, gasLimit uint64) error {
-	evm.SetPaygasMode(vm.PaygasHalt)
+	if evm.PaygasMode() != vm.PaygasHalt {
+		return ErrIncorrectAAConfig
+	}
 	evm.SetPaygasLimit(tx.Gas())
 	if gasLimit > tx.Gas() {
 		gasLimit = tx.Gas()

--- a/core/transaction_validator.go
+++ b/core/transaction_validator.go
@@ -27,15 +27,15 @@ var (
 )
 
 func Validate(tx *types.Transaction, s types.Signer, evm *vm.EVM, gasLimit uint64) error {
-	if evm.PaygasMode() != vm.PaygasHalt || evm.PaygasPrice().Sign() != 0 {
-		return ErrIncorrectAAConfig
+	evm.SetPaygasMode(vm.PaygasHalt)
+	evm.SetPaygasLimit(tx.Gas())
+	if gasLimit > tx.Gas() {
+		gasLimit = tx.Gas()
 	}
 	msg, err := tx.AsMessage(s)
+	msg.SetGas(gasLimit)
 	if err != nil {
 		return err
-	}
-	if gasLimit > msg.Gas() {
-		gasLimit = msg.Gas()
 	}
 	gp := new(GasPool).AddGas(gasLimit)
 	result, err := ApplyMessage(evm, msg, gp)

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -252,6 +252,12 @@ func (tx *Transaction) WithSignature(signer Signer, sig []byte) (*Transaction, e
 	return cpy, nil
 }
 
+func (tx *Transaction) WithAASignature() *Transaction {
+	cpy := &Transaction{data: tx.data}
+	cpy.data.V = big.NewInt(27)
+	return cpy
+}
+
 // Cost returns amount + gasprice * gaslimit.
 func (tx *Transaction) Cost() *big.Int {
 	total := new(big.Int).Mul(tx.data.Price, new(big.Int).SetUint64(tx.data.GasLimit))
@@ -407,6 +413,8 @@ type Message struct {
 	checkNonce bool
 	isAA       bool
 }
+
+var AADummyMessage = Message{from: common.NewEntryPointAddress(), gasPrice: big.NewInt(0)}
 
 func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte, checkNonce bool) Message {
 	isAA := from.IsEntryPoint()

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -423,15 +423,16 @@ func NewMessage(from common.Address, to *common.Address, nonce uint64, amount *b
 	}
 }
 
-func (m Message) From() common.Address { return m.from }
-func (m Message) To() *common.Address  { return m.to }
-func (m Message) GasPrice() *big.Int   { return m.gasPrice }
-func (m Message) Value() *big.Int      { return m.amount }
-func (m Message) Gas() uint64          { return m.gasLimit }
-func (m Message) Nonce() uint64        { return m.nonce }
-func (m Message) Data() []byte         { return m.data }
-func (m Message) CheckNonce() bool     { return m.checkNonce }
-func (m Message) IsAA() bool           { return m.isAA }
+func (m Message) From() common.Address    { return m.from }
+func (m Message) To() *common.Address     { return m.to }
+func (m Message) GasPrice() *big.Int      { return m.gasPrice }
+func (m Message) Value() *big.Int         { return m.amount }
+func (m Message) Gas() uint64             { return m.gasLimit }
+func (m Message) Nonce() uint64           { return m.nonce }
+func (m Message) Data() []byte            { return m.data }
+func (m Message) CheckNonce() bool        { return m.checkNonce }
+func (m Message) IsAA() bool              { return m.isAA }
+func (m *Message) SetGas(gasLimit uint64) { m.gasLimit = gasLimit }
 func (m Message) Sponsor() common.Address {
 	if !m.isAA {
 		return m.from

--- a/core/vm/errors.go
+++ b/core/vm/errors.go
@@ -34,7 +34,7 @@ var (
 	ErrWriteProtection          = errors.New("write protection")
 	ErrReturnDataOutOfBounds    = errors.New("return data out of bounds")
 	ErrGasUintOverflow          = errors.New("gas uint64 overflow")
-	ErrPaygasInsufficientFunds  = errors.New("insufficient funds for gas * price + value")
+	ErrPaygasInsufficientFunds  = errors.New("during paygas insufficient funds for gas * price + value")
 )
 
 // ErrStackUnderflow wraps an evm error when the items on the stack less

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -512,5 +512,6 @@ func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
 
 func (evm *EVM) PaygasMode() PaygasMode              { return evm.vmConfig.PaygasMode }
 func (evm *EVM) SetPaygasMode(paygasMode PaygasMode) { evm.vmConfig.PaygasMode = paygasMode }
+func (evm *EVM) PaygasLimit() uint64                 { return evm.vmConfig.paygasLimit }
 func (evm *EVM) SetPaygasLimit(paygasLimit uint64)   { evm.vmConfig.paygasLimit = paygasLimit }
 func (evm *EVM) PaygasPrice() *big.Int               { return evm.vmConfig.paygasPrice }


### PR DESCRIPTION
Simple tests complete.

**todo (optional)**: switch to one AA contract that takes as arguments:
* number of execution loops before calling `PAYGAS`
* whether or not to call `PAYGAS`
* `gasPrice` to return from `PAYGAS`