### PR TITLE
Basic AA Precompile Support

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -164,6 +164,7 @@ func newByzantiumInstructionSet() JumpTable {
 		memorySize:  memoryStaticCall,
 		valid:       true,
 		returns:     true,
+		internal:    true,
 	}
 	instructionSet[RETURNDATASIZE] = operation{
 		execute:     opReturnDataSize,


### PR DESCRIPTION
Adds support for `STATICCALL` to the precompile address range before `PAYGAS`.
The address range is determined as per [EIP 1352](https://eips.ethereum.org/EIPS/eip-1352). Note that this EIP is not yet accepted, but the address range should nonetheless be useable in this context.

Depends on https://github.com/quilt/go-ethereum/pull/23. Only new commit is https://github.com/quilt/go-ethereum/pull/24/commits/d6771d00d07334025855a09109787420aa79dda9.