### PR TITLE
internal/ethapi: add FeeCap, Tip and correct GasPrice to EIP-1559 RPCTransaction results

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1212,6 +1212,8 @@ type RPCTransaction struct {
 	From             common.Address    `json:"from"`
 	Gas              hexutil.Uint64    `json:"gas"`
 	GasPrice         *hexutil.Big      `json:"gasPrice"`
+	FeeCap           *hexutil.Big      `json:"feeCap,omitempty"`
+	Tip              *hexutil.Big      `json:"tip,omitempty"`
 	Hash             common.Hash       `json:"hash"`
 	Input            hexutil.Bytes     `json:"input"`
 	Nonce            hexutil.Uint64    `json:"nonce"`
@@ -1228,7 +1230,7 @@ type RPCTransaction struct {
 
 // newRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) *RPCTransaction {
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int) *RPCTransaction {
 	// Determine the signer. For replay-protected transactions, use the most permissive
 	// signer, because we assume that signers are backwards-compatible with old
 	// transactions. For non-protected transactions, the homestead signer signer is used
@@ -1261,17 +1263,32 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
 		result.TransactionIndex = (*hexutil.Uint64)(&index)
 	}
-	if tx.Type() == types.AccessListTxType {
+	switch tx.Type() {
+	case types.AccessListTxType:
 		al := tx.AccessList()
 		result.Accesses = &al
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
+	case types.DynamicFeeTxType:
+		al := tx.AccessList()
+		result.Accesses = &al
+		result.ChainID = (*hexutil.Big)(tx.ChainId())
+		result.FeeCap = (*hexutil.Big)(tx.FeeCap())
+		result.Tip = (*hexutil.Big)(tx.Tip())
+		// if the transaction has been mined, compute the effective gas price
+		if baseFee != nil && blockHash != (common.Hash{}) {
+			// price = min(tip, feeCap - baseFee) + baseFee
+			price := math.BigMin(new(big.Int).Add(tx.Tip(), baseFee), tx.FeeCap())
+			result.GasPrice = (*hexutil.Big)(price)
+		} else {
+			result.GasPrice = nil
+		}
 	}
 	return result
 }
 
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
 func newRPCPendingTransaction(tx *types.Transaction) *RPCTransaction {
-	return newRPCTransaction(tx, common.Hash{}, 0, 0)
+	return newRPCTransaction(tx, common.Hash{}, 0, 0, nil)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
@@ -1280,7 +1297,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64) *RPCTransacti
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index)
+	return newRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index, b.BaseFee())
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.
@@ -1495,7 +1512,11 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 		return nil, err
 	}
 	if tx != nil {
-		return newRPCTransaction(tx, blockHash, blockNumber, index), nil
+		block, err := s.b.BlockByHash(ctx, blockHash)
+		if err != nil {
+			return nil, err
+		}
+		return newRPCTransaction(tx, blockHash, blockNumber, index, block.BaseFee()), nil
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {


### PR DESCRIPTION
Fixed version of #47 which also correctly handles pending transactions.

Note that geth's console seems to coerce `gasPrice` to `0` when `null` so better to view the results via the raw JSONRPC interface:

```
$ echo '{"id":1, "jsonrpc": "2.0", "method": "eth_getTransactionByHash", "params": ["0x535342db97c28d27924cece6d0f45ae43a446d1a8fea67379e490cdef3a97bbe"]}' | nc -U ~/Library/Ethereum/aleut/geth.ipc | jq .

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": null,
    "blockNumber": null,
    "from": "0xdf0a88b2b68c673713a8ec826003676f272e3573",
    "gas": "0x5208",
    "gasPrice": null,
    "feeCap": "0x1",
    "tip": "0x0",
    "hash": "0x535342db97c28d27924cece6d0f45ae43a446d1a8fea67379e490cdef3a97bbe",
    "input": "0x",
    "nonce": "0x0",
    "to": "0x96216849c49358b10257cb55b28ea603c874b05e",
    "transactionIndex": null,
    "value": "0x1000",
    "type": "0x2",
    "accessList": [],
    "chainId": "0x1e8e",
    "v": "0x0",
    "r": "0x5f886d4d5a469bebe10153ef4d19d976fc638f3a539921d7cac0edd3809e62f5",
    "s": "0x668704b3c871f3b5e26cc532f0aab750710047b33cee47ebc8df162a1d3341ab"
  }
}
```

And here's a mined transaction, which returns the effective gas price in the `gasPrice` field:

```
$ echo '{"id":1, "jsonrpc": "2.0", "method": "eth_getTransactionByHash", "params": ["0xa91a8b53fdfdc3473ddc1f1942756b4455a53307da935719c559177f80959eb6"]}' | nc -U ~/Library/Ethereum/aleut/geth.ipc | jq . 

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "blockHash": "0x77386278ac94f0de28f99d9b00bd742d9ebf61237c50462bfc70cdd04f57dc44",
    "blockNumber": "0x37",
    "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
    "gas": "0x7530",
    "gasPrice": "0x257cbc",
    "feeCap": "0x12a05f200",
    "tip": "0x2",
    "hash": "0xa91a8b53fdfdc3473ddc1f1942756b4455a53307da935719c559177f80959eb6",
    "input": "0x",
    "nonce": "0x0",
    "to": "0x000000000000000000000000000000000000aaaa",
    "transactionIndex": "0x0",
    "value": "0x0",
    "type": "0x2",
    "accessList": [
      {
        "address": "0x000000000000000000000000000000000000aaaa",
        "storageKeys": [
          "0x0000000000000000000000000000000000000000000000000000000000000000"
        ]
      }
    ],
    "chainId": "0x1e8e",
    "v": "0x1",
    "r": "0xf700634eaffe6cf494e19a202de5e80ec336bcf759abfc32fcd1f88b570f0287",
    "s": "0x59c32a74c069b92b0d9eb905a2300d574682229f0916f1a41c434090603c92dd"
  }
}
```
