### PR TITLE
miner: make sure EIP-1559 blocks have .BaseFee set

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -653,6 +653,12 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 	}
 	state.StartPrefetcher("miner")
 
+	if w.chainConfig.IsAleut(parent.Number()) {
+		header.BaseFee = misc.CalcBaseFee(parent.Header())
+	} else if w.chainConfig.IsAleut(header.Number) {
+		header.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
+	}
+
 	env := &environment{
 		signer:    types.MakeSigner(w.chainConfig, header.Number),
 		state:     state,


### PR DESCRIPTION
Without this change, if I have any pending EIP-1559 transactions in my mempool (or serialized to transactions.rlp) I get this crash at startup:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104e58464]

goroutine 93 [running]:
math/big.(*Int).Cmp(0x140001b5760, 0x0, 0xffffffffffffffff)
	math/big/int.go:328 +0x44
github.com/ethereum/go-ethereum/core.(*StateTransition).preCheck(0x1400026cc00, 0x140002e0ac0, 0x140002e0b00)
	github.com/ethereum/go-ethereum/core/state_transition.go:223 +0xa8
github.com/ethereum/go-ethereum/core.(*StateTransition).TransitionDb(0x1400026cc00, 0x105d62748, 0x140001e0900, 0x1400003df50)
	github.com/ethereum/go-ethereum/core/state_transition.go:257 +0x30
github.com/ethereum/go-ethereum/core.ApplyMessage(0x140002a0000, 0x105d62748, 0x140001e0900, 0x1400003df50, 0x73352e27, 0x140001b5880, 0x140002e1dc0)
	github.com/ethereum/go-ethereum/core/state_transition.go:178 +0x4c
github.com/ethereum/go-ethereum/core.applyTransaction(0x1400003e5d0, 0x37678cb6b2880adf, 0x6f67036082eca813, 0x73352e27, 0x0, 0x140001b57e0, 0x5208, 0x140001b5720, 0x140001b5760, 0x140001b57a0, ...)
	github.com/ethereum/go-ethereum/core/state_processor.go:98 +0x134
github.com/ethereum/go-ethereum/core.ApplyTransaction(0x14000574420, 0x105d45ae0, 0x14000235200, 0x14001015748, 0x1400003df50, 0x140001e6b60, 0x140006c6b40, 0x14000226ba0, 0x140006c6d10, 0x0, ...)
	github.com/ethereum/go-ethereum/core/state_processor.go:149 +0x1e8
github.com/ethereum/go-ethereum/miner.(*worker).commitTransaction(0x14000ecefc0, 0x14000226ba0, 0x0, 0x0, 0xbe7ba9f300000000, 0x14073352e27, 0x0, 0x0, 0x14000fd7848, 0x104d57890)
	github.com/ethereum/go-ethereum/miner/worker.go:739 +0x12c
github.com/ethereum/go-ethereum/miner.(*worker).commitTransactions(0x14000ecefc0, 0x14001004420, 0x0, 0x0, 0x0, 0x1400003dac0, 0xc016957380fd4fa8)
	github.com/ethereum/go-ethereum/miner/worker.go:809 +0x3bc
github.com/ethereum/go-ethereum/miner.(*worker).commitNewWork(0x14000ecefc0, 0x1400003dac0, 0x0, 0x6079de4e)
	github.com/ethereum/go-ethereum/miner/worker.go:977 +0x7e8
github.com/ethereum/go-ethereum/miner.(*worker).mainLoop(0x14000ecefc0)
	github.com/ethereum/go-ethereum/miner/worker.go:441 +0x650
created by github.com/ethereum/go-ethereum/miner.newWorker
	github.com/ethereum/go-ethereum/miner/worker.go:227 +0x408
```

To root cause of the crash is that `.BaseFee` is nil here: https://github.com/quilt/go-ethereum/blob/76a9b3da53d8b974086ff06191b9fae1f9087a7c/core/state_transition.go#L223