### PR TITLE
internal/ethapi: add baseFee to RPCMarshalHeader

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1127,7 +1127,7 @@ func FormatLogs(logs []vm.StructLog) []StructLogRes {
 
 // RPCMarshalHeader converts the given header to the RPC output .
 func RPCMarshalHeader(head *types.Header) map[string]interface{} {
-	return map[string]interface{}{
+	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
 		"hash":             head.Hash(),
 		"parentHash":       head.ParentHash,
@@ -1146,6 +1146,12 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"transactionsRoot": head.TxHash,
 		"receiptsRoot":     head.ReceiptHash,
 	}
+
+	if head.BaseFee != nil {
+		result["baseFee"] = (*hexutil.Big)(head.BaseFee)
+	}
+
+	return result
 }
 
 // RPCMarshalBlock converts the given block to the RPC output which depends on fullTx. If inclTx is true transactions are


### PR DESCRIPTION
This adds the `baseFee` to JSONRPC responses for blocks such as `eth_getBlockByNumber`.

```
$ echo '{"id":1, "jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": ["pending", true]}' | nc -U ~/Library/Ethereum/aleut/geth.ipc | jq . 

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "baseFee": "0x7",
    "difficulty": "0x1",
    "extraData": "0xd983010a03846765746888676f312e31362e338664617277696e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "gasLimit": "0x130e0b6",
    "gasUsed": "0x0",
    "hash": null,
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "miner": null,
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": null,
    "number": "0xa91c",
    "parentHash": "0x4da0bb3afaeba157d6d7c15a7e87c47ac395e01bbee34cbf2b787ca8207a238b",
    "receiptsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "size": "0x262",
    "stateRoot": "0x4d580664a354de5403a8adb42de55391a4e0faf0e15460e9a291c5a2a01133d2",
    "timestamp": "0x6079fd9d",
    "totalDifficulty": null,
    "transactions": [],
    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "uncles": []
  }
}

$ echo '{"id":1, "jsonrpc": "2.0", "method": "eth_getBlockByHash", "params": ["0x77386278ac94f0de28f99d9b00bd742d9ebf61237c50462bfc70cdd04f57dc44", true]}' | nc -U ~/Library/Ethereum/aleut/geth.ipc | jq . 

{
  "jsonrpc": "2.0",
  "id": 1,
  "result": {
    "baseFee": "0x257cba",
    "difficulty": "0x2",
    "extraData": "0x00000000000000000000000000000000000000000000000000000000000000004038bec6427396c8f6f4044668543c368ad5acab1eb9d556075816d25ea90b7b17958594cbd8dc5058c280e1286472d784ea89cc92587854cbeae1272567d36400",
    "gasLimit": "0x1312d00",
    "gasUsed": "0x62d4",
    "hash": "0x77386278ac94f0de28f99d9b00bd742d9ebf61237c50462bfc70cdd04f57dc44",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "miner": "0x0000000000000000000000000000000000000000",
    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
    "nonce": "0x0000000000000000",
    "number": "0x37",
    "parentHash": "0x34ce2279ab20504ed0db3b1983c0f31511dc5dac1ad9325435abe3768ee36006",
    "receiptsRoot": "0x0123faa8e8c4942483db2ab5ea400639bba7b8dfe24ad288c83c7aad4e87a983",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "size": "0x30d",
    "stateRoot": "0x0f170da3059a0098c195b0252f72080d9222482d6cd19cd535e7331dcfb53e15",
    "timestamp": "0x60701455",
    "totalDifficulty": "0x46e",
    "transactions": [
      {
        "blockHash": "0x77386278ac94f0de28f99d9b00bd742d9ebf61237c50462bfc70cdd04f57dc44",
        "blockNumber": "0x37",
        "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
        "gas": "0x7530",
        "gasPrice": "0x2",
        "hash": "0xa91a8b53fdfdc3473ddc1f1942756b4455a53307da935719c559177f80959eb6",
        "input": "0x",
        "nonce": "0x0",
        "to": "0x000000000000000000000000000000000000aaaa",
        "transactionIndex": "0x0",
        "value": "0x0",
        "type": "0x2",
        "v": "0x1",
        "r": "0xf700634eaffe6cf494e19a202de5e80ec336bcf759abfc32fcd1f88b570f0287",
        "s": "0x59c32a74c069b92b0d9eb905a2300d574682229f0916f1a41c434090603c92dd"
      }
    ],
    "transactionsRoot": "0x66ce8e18b51451786a6ebb37d52e8864364a8902b2518be986b75bf061eef6be",
    "uncles": []
  }
}
```